### PR TITLE
Add CHNOSZ vignette

### DIFF
--- a/content/knitr/demo/2013-03-11-showcase.md
+++ b/content/knitr/demo/2013-03-11-showcase.md
@@ -65,6 +65,7 @@ Below is a list of the book reviews on [Dynamic Documents with R and knitr](http
 - the [ggplot2 transition guide](https://github.com/djmurphy420/ggplot2-transition-guide) to version 0.9.0 by Dennis Murphy et al
 - a few packages on Bioconductor: [ReportingTools](http://www.bioconductor.org/packages/2.12/bioc/vignettes/ReportingTools/inst/doc/knitr.html) and [RGalaxy](http://www.bioconductor.org/packages/2.12/bioc/html/RGalaxy.html)
 - [the dendextend package](https://github.com/talgalili/dendextend) by Tal Galili
+- [An Introduction to CHNOSZ](http://chnosz.net/vignettes/anintro.html) vignette by Jeffrey M. Dick using Tufte style
 
 ## Courses
 


### PR DESCRIPTION
This PR adds a link to the vignette "An Introduction to CHNOSZ", which uses knitr and the tufte package.