### PR TITLE
调整 GitHub Edit 链接修复

### DIFF
--- a/layouts/partials/article_meta.html
+++ b/layouts/partials/article_meta.html
@@ -18,7 +18,7 @@
     <a href="http://service.weibo.com/share/share.php?{{ (querify "content" "utf-8" "url" .Permalink "title" (print .Title " @" .Site.Params.social.weibo)) | safeURL }}" target="_blank"><i class="fa fa-weibo" aria-hidden="true" title="分享到新浪微博"></i></a>
     <a href="http://creativecommons.org/licenses/by-nc-sa/4.0/"><i class="fa fa-cc" aria-hidden="true" title="Attribution-NonCommercial-ShareAlike 4.0 International"></i></a>
     {{ with .Site.Params.githubContentURL }}
-    {{ $.Scratch.Set "filePath" $.File.Path }}
+    {{ $.Scratch.Set "filePath" (replace $.File.Path "\\" "/") }}
     {{ if $.Params.from_Rmd }}
     {{ $.Scratch.Set "filePath" (replaceRE "[.]md$" ".Rmd" $.File.Path) }}
     {{ end }}


### PR DESCRIPTION
在 Win 上的 URL 地址中可能包含一个 `%5c`，导致链接指向不正确。