### PR TITLE
Add numeric error chunk options

### DIFF
--- a/content/knitr/options.md
+++ b/content/knitr/options.md
@@ -180,8 +180,13 @@ Below is a list of chunk options in **knitr** documented in the format
     want to stop on errors, we need to set this option to `FALSE`. Note that R
     Markdown has changed this default value to `FALSE`. When the chunk option
     `include = FALSE`, **knitr** will stop on error, because it is easy to
-    overlook potential errors in this case (if you understand this caveat and
-    want to ignore potential errors anyway, you may set `error = 0`).
+    overlook potential errors in this case. If you understand this caveat and
+    want to handle potential errors yourself, you may set `error` to numerical
+    values as they are defined by `evaluate::evaluate()`: `0L` keeps evaluating
+    after errors as if you had pasted the text into a terminal, `1L` stops
+    evaluation after an error but then ends normally (To manually handle errors,
+    you can use the error hook, see the hook section). A value of `2L` makes
+    the knitr call fail on encountering an error.
 
 -   `message`: (`TRUE`; logical) Whether to preserve messages emitted by
     `message()` (similar to the option `warning`).


### PR DESCRIPTION
Numerical values are already forwarded to evaluate::evaluate() in the code, allowing for custom error handling in conjunction with the error chunk hook. If setting `knitr::options(error = 1L)`, this allows for a behaviour that uses the output MD file similarly to the terminal output of  `R CMD BATCH`: The code and the output are output, up to the point of an error, then the error message is printed and then the program fails. This is a nice behaviour that should be also documented.