### PR TITLE
文鼎楷体简体换为更可信来源，增加文鼎楷体繁体

### DIFF
--- a/static/css/fonts.css
+++ b/static/css/fonts.css
@@ -8,7 +8,7 @@
 @font-face {
   font-family: 'Kai';
   src: local('Kaiti'), local('Kaiti SC'), local('STKaiti'), local('楷体'), local('SimKai'), local('AR PL KaitiM GB'), local('DFKai-SB'), local('FandolKai'),
-       url('https://cdn.jsdelivr.net/gh/yihui/cron/fonts/gkai00mp-yihui.woff2') format('woff2');
+       url('https://cdn.jsdelivr.net/gh/yihui/cron/fonts/gkai00mp-yihui.woff2') format('woff2'),
        url('https://cdn.jsdelivr.net/gh/yihui/cron/fonts/bkai00mp-yihui.woff2') format('woff2');
 }
 body {

--- a/static/css/fonts.css
+++ b/static/css/fonts.css
@@ -6,22 +6,19 @@
        url('https://cdn.jsdelivr.net/gh/yihui/cron/fonts/SourceHanSerifCN-Regular-yihui.woff2') format('woff2');
 }
 @font-face {
-  font-family: 'Base Kai';
+  font-family: 'Kai';
   src: local('Kaiti'), local('Kaiti SC'), local('STKaiti'), local('楷体'), local('SimKai'), local('AR PL KaitiM GB'), local('DFKai-SB'), local('FandolKai'),
        url('https://cdn.jsdelivr.net/gh/yihui/cron/fonts/gkai00mp-yihui.woff2') format('woff2');
-}
-@font-face {
-  font-family: 'Extra Kai';
-  src: url('https://cdn.jsdelivr.net/gh/yihui/cron/fonts/bkai00mp-yihui.woff2') format('woff2');
+       url('https://cdn.jsdelivr.net/gh/yihui/cron/fonts/bkai00mp-yihui.woff2') format('woff2');
 }
 body {
   font-family: Palatino, 'Palatino Linotype', 'Palatino LT STD', 'Latin Modern Roman', 'Source Han Serif CN', serif;
 }
 .home blockquote, .cn blockquote, .kai, .cn em, .cn .side, .hash-note, .hide-notes .toggle-notes {
-  font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, 'Base Kai', 'Extra Kai', serif;
+  font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Kai, serif;
 }
 code {
-  font-family: Consolas, Courier, 'Lucida Console', 'Courier New', 'Base Kai', 'Extra Kai', monospace;
+  font-family: Consolas, Courier, 'Lucida Console', 'Courier New', Kai, monospace;
 }
 pre, code {
   font-size: .95em;

--- a/static/css/fonts.css
+++ b/static/css/fonts.css
@@ -14,7 +14,6 @@
   font-family: 'Extra Kai';
   src: url('https://cdn.jsdelivr.net/gh/yihui/cron/fonts/bkai00mp-yihui.woff2') format('woff2');
 }
-
 body {
   font-family: Palatino, 'Palatino Linotype', 'Palatino LT STD', 'Latin Modern Roman', 'Source Han Serif CN', serif;
 }

--- a/static/css/fonts.css
+++ b/static/css/fonts.css
@@ -6,18 +6,23 @@
        url('https://cdn.jsdelivr.net/gh/yihui/cron/fonts/SourceHanSerifCN-Regular-yihui.woff2') format('woff2');
 }
 @font-face {
-  font-family: 'FandolKai';
+  font-family: 'Base Kai';
   src: local('Kaiti'), local('Kaiti SC'), local('STKaiti'), local('楷体'), local('SimKai'), local('AR PL KaitiM GB'), local('DFKai-SB'), local('FandolKai'),
-       url('https://cdn.jsdelivr.net/gh/yihui/cron/fonts/AR-PL-KaitiM-GB-yihui.woff2') format('woff2');
+       url('https://cdn.jsdelivr.net/gh/yihui/cron/fonts/gkai00mp-yihui.woff2') format('woff2');
 }
+@font-face {
+  font-family: 'Extra Kai';
+  src: url('https://cdn.jsdelivr.net/gh/yihui/cron/fonts/bkai00mp-yihui.woff2') format('woff2');
+}
+
 body {
   font-family: Palatino, 'Palatino Linotype', 'Palatino LT STD', 'Latin Modern Roman', 'Source Han Serif CN', serif;
 }
 .home blockquote, .cn blockquote, .kai, .cn em, .cn .side, .hash-note, .hide-notes .toggle-notes {
-  font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, FandolKai, serif;
+  font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, 'Base Kai', 'Extra Kai', serif;
 }
 code {
-  font-family: Consolas, Courier, 'Lucida Console', 'Courier New', FandolKai, monospace;
+  font-family: Consolas, Courier, 'Lucida Console', 'Courier New', 'Base Kai', 'Extra Kai', monospace;
 }
 pre, code {
   font-size: .95em;


### PR DESCRIPTION
解决 <https://github.com/yihui/yihui.org/issues/1553> 中提到的繁体字云端嵌入楷体无法正常渲染问题。